### PR TITLE
[v1.4.0] Add support for key files

### DIFF
--- a/StreamDeck-KeePass/StreamDeck-KeePass/KeePassRetrieve.cs
+++ b/StreamDeck-KeePass/StreamDeck-KeePass/KeePassRetrieve.cs
@@ -21,6 +21,7 @@ namespace StreamDeck_KeePass
                 {
                     DBPath = string.Empty,
                     Password = string.Empty,
+                    KeyFilePath = string.Empty,
                     EntryTitle = string.Empty,
                     Field = string.Empty
                 };
@@ -33,6 +34,9 @@ namespace StreamDeck_KeePass
 
             [JsonProperty(PropertyName = "Password")]
             public string Password { get; set; }
+
+            [JsonProperty(PropertyName = "keyFilePath")]
+            public string KeyFilePath { get; set; }
 
             [JsonProperty(PropertyName = "entryTitle")]
             public string EntryTitle { get; set; }
@@ -70,6 +74,10 @@ namespace StreamDeck_KeePass
                 var conn = new IOConnectionInfo { Path = settings.DBPath };
                 var compKey = new CompositeKey();
                 compKey.AddUserKey(new KcpPassword(settings.Password));
+                if (!string.IsNullOrEmpty(settings.KeyFilePath))
+                {
+                    compKey.AddUserKey(new KcpKeyFile(settings.KeyFilePath));
+                }
                 var db = new KeePassLib.PwDatabase();
                 db.Open(conn, compKey, null);
                 var entryList = from entry in db.RootGroup.GetEntries(true)

--- a/StreamDeck-KeePass/StreamDeck-KeePass/PropertyInspector/KeePassRetrievePI.html
+++ b/StreamDeck-KeePass/StreamDeck-KeePass/PropertyInspector/KeePassRetrievePI.html
@@ -16,6 +16,10 @@
             <input class="sdpi-item-value sdProperty" placeholder="The filepath to your KeePass .kdbx" value="" id="DBPath">
         </div>
         <div class="sdpi-item" id="dvPassword">
+            <div class="sdpi-item-label">(Optional) Key File path</div>
+            <input class="sdpi-item-value sdProperty" placeholder="The path of the key file for the .kdbx" value="" id="keyFilePath" oninput="setSettings()">
+        </div>
+        <div class="sdpi-item" id="dvPassword">
             <div class="sdpi-item-label">KeePass db password</div>
             <input class="sdpi-item-value sdProperty" placeholder="The password for the .kdbx" value="" id="Password" oninput="setSettings()" type="password">
         </div>

--- a/StreamDeck-KeePass/StreamDeck-KeePass/manifest.json
+++ b/StreamDeck-KeePass/StreamDeck-KeePass/manifest.json
@@ -36,7 +36,7 @@
   "Description": "Simple interface to retrieve information from KeePass database. Unofficial.",
   "Icon": "Images/pluginIcon",
   "URL": "https://github.com/VictorGrycuk/StreamDeck-KeePass",
-  "Version": "1.3.1",
+  "Version": "1.4.0",
   "CodePath": "streamdeck-keepass",
   "Category": "KeePass",
   "CategoryIcon": "Images/categoryIcon",


### PR DESCRIPTION
Fixes #6 

Adds a new optional configuration:
- `(Optional) Key File path`: If specified, it will be used to open the `.kdbx` file